### PR TITLE
Add new (required) versions and fix bug with some case comparisons

### DIFF
--- a/database/oracle/oracle_version.sql
+++ b/database/oracle/oracle_version.sql
@@ -17,6 +17,7 @@ COL is_ver_eq_12_2     NEW_V is_ver_eq_12_2     NOPRI
 COL is_ver_eq_12       NEW_V is_ver_eq_12       NOPRI
 COL is_ver_eq_18       NEW_V is_ver_eq_18       NOPRI
 COL is_ver_eq_19       NEW_V is_ver_eq_19       NOPRI
+COL is_ver_eq_19_7     NEW_V is_ver_eq_19_7     NOPRI
 COL is_ver_eq_19_10    NEW_V is_ver_eq_19_10    NOPRI
 COL is_ver_eq_19_11    NEW_V is_ver_eq_19_11    NOPRI
 COL is_ver_eq_21       NEW_V is_ver_eq_21       NOPRI
@@ -40,6 +41,7 @@ COL is_ver_le_12_2     NEW_V is_ver_le_12_2     NOPRI
 COL is_ver_le_12       NEW_V is_ver_le_12       NOPRI
 COL is_ver_le_18       NEW_V is_ver_le_18       NOPRI
 COL is_ver_le_19       NEW_V is_ver_le_19       NOPRI
+COL is_ver_le_19_7     NEW_V is_ver_le_19_7     NOPRI
 COL is_ver_le_19_10    NEW_V is_ver_le_19_10    NOPRI
 COL is_ver_le_19_11    NEW_V is_ver_le_19_11    NOPRI
 COL is_ver_le_21       NEW_V is_ver_le_21       NOPRI
@@ -63,6 +65,7 @@ COL is_ver_ge_12_2     NEW_V is_ver_ge_12_2     NOPRI
 COL is_ver_ge_12       NEW_V is_ver_ge_12       NOPRI
 COL is_ver_ge_18       NEW_V is_ver_ge_18       NOPRI
 COL is_ver_ge_19       NEW_V is_ver_ge_19       NOPRI
+COL is_ver_ge_19_7     NEW_V is_ver_ge_19_7     NOPRI
 COL is_ver_ge_19_10    NEW_V is_ver_ge_19_10    NOPRI
 COL is_ver_ge_19_11    NEW_V is_ver_ge_19_11    NOPRI
 COL is_ver_ge_21       NEW_V is_ver_ge_21       NOPRI
@@ -87,6 +90,7 @@ COL skip_ver_eq_12_2   NEW_V skip_ver_eq_12_2   NOPRI
 COL skip_ver_eq_12     NEW_V skip_ver_eq_12     NOPRI
 COL skip_ver_eq_18     NEW_V skip_ver_eq_18     NOPRI
 COL skip_ver_eq_19     NEW_V skip_ver_eq_19     NOPRI
+COL skip_ver_eq_19_7   NEW_V skip_ver_eq_19_7   NOPRI
 COL skip_ver_eq_19_10  NEW_V skip_ver_eq_19_10  NOPRI
 COL skip_ver_eq_19_11  NEW_V skip_ver_eq_19_11  NOPRI
 COL skip_ver_eq_21     NEW_V skip_ver_eq_21     NOPRI
@@ -110,6 +114,7 @@ COL skip_ver_le_12_2   NEW_V skip_ver_le_12_2   NOPRI
 COL skip_ver_le_12     NEW_V skip_ver_le_12     NOPRI
 COL skip_ver_le_18     NEW_V skip_ver_le_18     NOPRI
 COL skip_ver_le_19     NEW_V skip_ver_le_19     NOPRI
+COL skip_ver_le_19_7   NEW_V skip_ver_le_19_7   NOPRI
 COL skip_ver_le_19_10  NEW_V skip_ver_le_19_10  NOPRI
 COL skip_ver_le_19_11  NEW_V skip_ver_le_19_11  NOPRI
 COL skip_ver_le_21     NEW_V skip_ver_le_21     NOPRI
@@ -133,6 +138,7 @@ COL skip_ver_ge_12_2   NEW_V skip_ver_ge_12_2   NOPRI
 COL skip_ver_ge_12     NEW_V skip_ver_ge_12     NOPRI
 COL skip_ver_ge_18     NEW_V skip_ver_ge_18     NOPRI
 COL skip_ver_ge_19     NEW_V skip_ver_ge_19     NOPRI
+COL skip_ver_ge_19_7   NEW_V skip_ver_ge_19_7   NOPRI
 COL skip_ver_ge_19_10  NEW_V skip_ver_ge_19_10  NOPRI
 COL skip_ver_ge_19_11  NEW_V skip_ver_ge_19_11  NOPRI
 COL skip_ver_ge_21     NEW_V skip_ver_ge_21     NOPRI
@@ -165,6 +171,7 @@ select -- Equal
        case when version = 12                                      then 'Y' else 'N' end is_ver_eq_12,
        case when version = 18                                      then 'Y' else 'N' end is_ver_eq_18,
        case when version = 19                                      then 'Y' else 'N' end is_ver_eq_19,
+       case when version = 19 and release = 7                      then 'Y' else 'N' end is_ver_eq_19_7,
        case when version = 19 and release = 10                     then 'Y' else 'N' end is_ver_eq_19_10,
        case when version = 19 and release = 11                     then 'Y' else 'N' end is_ver_eq_19_11,
        case when version = 21                                      then 'Y' else 'N' end is_ver_eq_21,
@@ -195,6 +202,7 @@ select -- Equal
        case when version <= 12                                     then 'Y' else 'N' end is_ver_le_12,
        case when version <= 18                                     then 'Y' else 'N' end is_ver_le_18,
        case when version <= 19                                     then 'Y' else 'N' end is_ver_le_19,
+       case when version <  19 or (version = 19 and release <= 7)  then 'Y' else 'N' end is_ver_le_19_7,
        case when version <  19 or (version = 19 and release <= 10) then 'Y' else 'N' end is_ver_le_19_10,
        case when version <  19 or (version = 19 and release <= 11) then 'Y' else 'N' end is_ver_le_19_11,
        case when version <= 21                                     then 'Y' else 'N' end is_ver_le_21,
@@ -222,6 +230,7 @@ select -- Equal
        case when version >= 12                                     then 'Y' else 'N' end is_ver_ge_12,
        case when version >= 18                                     then 'Y' else 'N' end is_ver_ge_18,
        case when version >= 19                                     then 'Y' else 'N' end is_ver_ge_19,
+       case when version >  19 or (version = 19 and release >= 7)  then 'Y' else 'N' end is_ver_ge_19_7,
        case when version >  19 or (version = 19 and release >= 10) then 'Y' else 'N' end is_ver_ge_19_10,
        case when version >  19 or (version = 19 and release >= 11) then 'Y' else 'N' end is_ver_ge_19_11,
        case when version >= 21                                     then 'Y' else 'N' end is_ver_ge_21,
@@ -251,6 +260,7 @@ select -- Equal
        decode('&&is_ver_eq_12.'     ,'Y','--','N','') skip_ver_eq_12,
        decode('&&is_ver_eq_18.'     ,'Y','--','N','') skip_ver_eq_18,
        decode('&&is_ver_eq_19.'     ,'Y','--','N','') skip_ver_eq_19,
+       decode('&&is_ver_eq_19_7.'   ,'Y','--','N','') skip_ver_eq_19_7,
        decode('&&is_ver_eq_19_10.'  ,'Y','--','N','') skip_ver_eq_19_10,
        decode('&&is_ver_eq_19_11.'  ,'Y','--','N','') skip_ver_eq_19_11,
        decode('&&is_ver_eq_21.'     ,'Y','--','N','') skip_ver_eq_21,
@@ -274,6 +284,7 @@ select -- Equal
        decode('&&is_ver_le_12.'     ,'Y','--','N','') skip_ver_le_12,
        decode('&&is_ver_le_18.'     ,'Y','--','N','') skip_ver_le_18,
        decode('&&is_ver_le_19.'     ,'Y','--','N','') skip_ver_le_19,
+       decode('&&is_ver_le_19_7.'   ,'Y','--','N','') skip_ver_le_19_7,
        decode('&&is_ver_le_19_10.'  ,'Y','--','N','') skip_ver_le_19_10,
        decode('&&is_ver_le_19_11.'  ,'Y','--','N','') skip_ver_le_19_11,
        decode('&&is_ver_le_21.'     ,'Y','--','N','') skip_ver_le_21,
@@ -297,6 +308,7 @@ select -- Equal
        decode('&&is_ver_ge_12.'     ,'Y','--','N','') skip_ver_ge_12,
        decode('&&is_ver_ge_18.'     ,'Y','--','N','') skip_ver_ge_18,
        decode('&&is_ver_ge_19.'     ,'Y','--','N','') skip_ver_ge_19,
+       decode('&&is_ver_ge_19_7.'   ,'Y','--','N','') skip_ver_ge_19_7,
        decode('&&is_ver_ge_19_10.'  ,'Y','--','N','') skip_ver_ge_19_10,
        decode('&&is_ver_ge_19_11.'  ,'Y','--','N','') skip_ver_ge_19_11,
        decode('&&is_ver_ge_21.'     ,'Y','--','N','') skip_ver_ge_21,
@@ -321,6 +333,7 @@ COL is_ver_eq_12_2     CLEAR
 COL is_ver_eq_12       CLEAR
 COL is_ver_eq_18       CLEAR
 COL is_ver_eq_19       CLEAR
+COL is_ver_eq_19_7     CLEAR
 COL is_ver_eq_19_10    CLEAR
 COL is_ver_eq_19_11    CLEAR
 COL is_ver_eq_21       CLEAR
@@ -344,6 +357,7 @@ COL is_ver_le_12_2     CLEAR
 COL is_ver_le_12       CLEAR
 COL is_ver_le_18       CLEAR
 COL is_ver_le_19       CLEAR
+COL is_ver_le_19_7     CLEAR
 COL is_ver_le_19_10    CLEAR
 COL is_ver_le_19_11    CLEAR
 COL is_ver_le_21       CLEAR
@@ -367,6 +381,7 @@ COL is_ver_ge_12_2     CLEAR
 COL is_ver_ge_12       CLEAR
 COL is_ver_ge_18       CLEAR
 COL is_ver_ge_19       CLEAR
+COL is_ver_ge_19_7     CLEAR
 COL is_ver_ge_19_10    CLEAR
 COL is_ver_ge_19_11    CLEAR
 COL is_ver_ge_21       CLEAR
@@ -390,6 +405,7 @@ COL skip_ver_eq_12_2   CLEAR
 COL skip_ver_eq_12     CLEAR
 COL skip_ver_eq_18     CLEAR
 COL skip_ver_eq_19     CLEAR
+COL skip_ver_eq_19_7   CLEAR
 COL skip_ver_eq_19_10  CLEAR
 COL skip_ver_eq_19_11  CLEAR
 COL skip_ver_eq_21     CLEAR
@@ -413,6 +429,7 @@ COL skip_ver_le_12_2   CLEAR
 COL skip_ver_le_12     CLEAR
 COL skip_ver_le_18     CLEAR
 COL skip_ver_le_19     CLEAR
+COL skip_ver_le_19_7   CLEAR
 COL skip_ver_le_19_10  CLEAR
 COL skip_ver_le_19_11  CLEAR
 COL skip_ver_le_21     CLEAR
@@ -436,6 +453,7 @@ COL skip_ver_ge_12_2   CLEAR
 COL skip_ver_ge_12     CLEAR
 COL skip_ver_ge_18     CLEAR
 COL skip_ver_ge_19     CLEAR
+COL skip_ver_ge_19_7   CLEAR
 COL skip_ver_ge_19_10  CLEAR
 COL skip_ver_ge_19_11  CLEAR
 COL skip_ver_ge_21     CLEAR

--- a/database/oracle/oracle_version.sql
+++ b/database/oracle/oracle_version.sql
@@ -1,176 +1,235 @@
 -- Set version variables. Value will be 'Y' or 'N'
-COL is_ver_eq_9_1      new_v is_ver_eq_9_1      nopri
-COL is_ver_eq_9_2      new_v is_ver_eq_9_2      nopri
-COL is_ver_eq_9        new_v is_ver_eq_9        nopri
-COL is_ver_eq_10_1     new_v is_ver_eq_10_1     nopri
-COL is_ver_eq_10_2     new_v is_ver_eq_10_2     nopri
-COL is_ver_eq_10       new_v is_ver_eq_10       nopri
-COL is_ver_eq_11_1     new_v is_ver_eq_11_1     nopri
-COL is_ver_eq_11_2     new_v is_ver_eq_11_2     nopri
-COL is_ver_eq_11_201   new_v is_ver_eq_11_201   nopri
-COL is_ver_eq_11_203   new_v is_ver_eq_11_203   nopri
-COL is_ver_eq_11       new_v is_ver_eq_11       nopri
-COL is_ver_eq_12_1     new_v is_ver_eq_12_1     nopri
-COL is_ver_eq_12_101   new_v is_ver_eq_12_101   nopri
-COL is_ver_eq_12_2     new_v is_ver_eq_12_2     nopri
-COL is_ver_eq_12       new_v is_ver_eq_12       nopri
-COL is_ver_eq_18       new_v is_ver_eq_18       nopri
-COL is_ver_eq_19       new_v is_ver_eq_19       nopri
-COL is_ver_eq_20       new_v is_ver_eq_20       nopri
+COL is_ver_eq_9_1      NEW_V is_ver_eq_9_1      NOPRI
+COL is_ver_eq_9_2      NEW_V is_ver_eq_9_2      NOPRI
+COL is_ver_eq_9        NEW_V is_ver_eq_9        NOPRI
+COL is_ver_eq_10_1     NEW_V is_ver_eq_10_1     NOPRI
+COL is_ver_eq_10_2     NEW_V is_ver_eq_10_2     NOPRI
+COL is_ver_eq_10       NEW_V is_ver_eq_10       NOPRI
+COL is_ver_eq_11_1     NEW_V is_ver_eq_11_1     NOPRI
+COL is_ver_eq_11_2     NEW_V is_ver_eq_11_2     NOPRI
+COL is_ver_eq_11_201   NEW_V is_ver_eq_11_201   NOPRI
+COL is_ver_eq_11_203   NEW_V is_ver_eq_11_203   NOPRI
+COL is_ver_eq_11_204   NEW_V is_ver_eq_11_204   NOPRI
+COL is_ver_eq_11       NEW_V is_ver_eq_11       NOPRI
+COL is_ver_eq_12_1     NEW_V is_ver_eq_12_1     NOPRI
+COL is_ver_eq_12_101   NEW_V is_ver_eq_12_101   NOPRI
+COL is_ver_eq_12_2     NEW_V is_ver_eq_12_2     NOPRI
+COL is_ver_eq_12       NEW_V is_ver_eq_12       NOPRI
+COL is_ver_eq_18       NEW_V is_ver_eq_18       NOPRI
+COL is_ver_eq_19       NEW_V is_ver_eq_19       NOPRI
+COL is_ver_eq_19_10    NEW_V is_ver_eq_19_10    NOPRI
+COL is_ver_eq_19_11    NEW_V is_ver_eq_19_11    NOPRI
+COL is_ver_eq_21       NEW_V is_ver_eq_21       NOPRI
+COL is_ver_eq_23       NEW_V is_ver_eq_23       NOPRI
 
-COL is_ver_le_9_1      new_v is_ver_le_9_1      nopri
-COL is_ver_le_9_2      new_v is_ver_le_9_2      nopri
-COL is_ver_le_9        new_v is_ver_le_9        nopri
-COL is_ver_le_10_1     new_v is_ver_le_10_1     nopri
-COL is_ver_le_10_2     new_v is_ver_le_10_2     nopri
-COL is_ver_le_10       new_v is_ver_le_10       nopri
-COL is_ver_le_11_1     new_v is_ver_le_11_1     nopri
-COL is_ver_le_11_2     new_v is_ver_le_11_2     nopri
-COL is_ver_le_11_201   new_v is_ver_le_11_201   nopri
-COL is_ver_le_11_203   new_v is_ver_le_11_203   nopri
-COL is_ver_le_11       new_v is_ver_le_11       nopri
-COL is_ver_le_12_1     new_v is_ver_le_12_1     nopri
-COL is_ver_le_12_101   new_v is_ver_le_12_101   nopri
-COL is_ver_le_12_2     new_v is_ver_le_12_2     nopri
-COL is_ver_le_12       new_v is_ver_le_12       nopri
-COL is_ver_le_18       new_v is_ver_le_18       nopri
-COL is_ver_le_19       new_v is_ver_le_19       nopri
-COL is_ver_le_20       new_v is_ver_le_20       nopri
+COL is_ver_le_9_1      NEW_V is_ver_le_9_1      NOPRI
+COL is_ver_le_9_2      NEW_V is_ver_le_9_2      NOPRI
+COL is_ver_le_9        NEW_V is_ver_le_9        NOPRI
+COL is_ver_le_10_1     NEW_V is_ver_le_10_1     NOPRI
+COL is_ver_le_10_2     NEW_V is_ver_le_10_2     NOPRI
+COL is_ver_le_10       NEW_V is_ver_le_10       NOPRI
+COL is_ver_le_11_1     NEW_V is_ver_le_11_1     NOPRI
+COL is_ver_le_11_2     NEW_V is_ver_le_11_2     NOPRI
+COL is_ver_le_11_201   NEW_V is_ver_le_11_201   NOPRI
+COL is_ver_le_11_203   NEW_V is_ver_le_11_203   NOPRI
+COL is_ver_le_11_204   NEW_V is_ver_le_11_204   NOPRI
+COL is_ver_le_11       NEW_V is_ver_le_11       NOPRI
+COL is_ver_le_12_1     NEW_V is_ver_le_12_1     NOPRI
+COL is_ver_le_12_101   NEW_V is_ver_le_12_101   NOPRI
+COL is_ver_le_12_2     NEW_V is_ver_le_12_2     NOPRI
+COL is_ver_le_12       NEW_V is_ver_le_12       NOPRI
+COL is_ver_le_18       NEW_V is_ver_le_18       NOPRI
+COL is_ver_le_19       NEW_V is_ver_le_19       NOPRI
+COL is_ver_le_19_10    NEW_V is_ver_le_19_10    NOPRI
+COL is_ver_le_19_11    NEW_V is_ver_le_19_11    NOPRI
+COL is_ver_le_21       NEW_V is_ver_le_21       NOPRI
+COL is_ver_le_23       NEW_V is_ver_le_23       NOPRI
 --
-COL is_ver_ge_9_1      new_v is_ver_ge_9_1      nopri
-COL is_ver_ge_9_2      new_v is_ver_ge_9_2      nopri
-COL is_ver_ge_9        new_v is_ver_ge_9        nopri
-COL is_ver_ge_10_1     new_v is_ver_ge_10_1     nopri
-COL is_ver_ge_10_2     new_v is_ver_ge_10_2     nopri
-COL is_ver_ge_10       new_v is_ver_ge_10       nopri
-COL is_ver_ge_11_1     new_v is_ver_ge_11_1     nopri
-COL is_ver_ge_11_2     new_v is_ver_ge_11_2     nopri
-COL is_ver_ge_11       new_v is_ver_ge_11       nopri
-COL is_ver_ge_12_1     new_v is_ver_ge_12_1     nopri
-COL is_ver_ge_12_2     new_v is_ver_ge_12_2     nopri
-COL is_ver_ge_12       new_v is_ver_ge_12       nopri
-COL is_ver_ge_18       new_v is_ver_ge_18       nopri
-COL is_ver_ge_19       new_v is_ver_ge_19       nopri
-COL is_ver_ge_20       new_v is_ver_ge_20       nopri
+COL is_ver_ge_9_1      NEW_V is_ver_ge_9_1      NOPRI
+COL is_ver_ge_9_2      NEW_V is_ver_ge_9_2      NOPRI
+COL is_ver_ge_9        NEW_V is_ver_ge_9        NOPRI
+COL is_ver_ge_10_1     NEW_V is_ver_ge_10_1     NOPRI
+COL is_ver_ge_10_2     NEW_V is_ver_ge_10_2     NOPRI
+COL is_ver_ge_10       NEW_V is_ver_ge_10       NOPRI
+COL is_ver_ge_11_1     NEW_V is_ver_ge_11_1     NOPRI
+COL is_ver_ge_11_2     NEW_V is_ver_ge_11_2     NOPRI
+COL is_ver_ge_11_201   NEW_V is_ver_ge_11_201   NOPRI
+COL is_ver_ge_11_203   NEW_V is_ver_ge_11_203   NOPRI
+COL is_ver_ge_11_204   NEW_V is_ver_ge_11_204   NOPRI
+COL is_ver_ge_11       NEW_V is_ver_ge_11       NOPRI
+COL is_ver_ge_12_1     NEW_V is_ver_ge_12_1     NOPRI
+COL is_ver_ge_12_101   NEW_V is_ver_ge_12_101   NOPRI
+COL is_ver_ge_12_2     NEW_V is_ver_ge_12_2     NOPRI
+COL is_ver_ge_12       NEW_V is_ver_ge_12       NOPRI
+COL is_ver_ge_18       NEW_V is_ver_ge_18       NOPRI
+COL is_ver_ge_19       NEW_V is_ver_ge_19       NOPRI
+COL is_ver_ge_19_10    NEW_V is_ver_ge_19_10    NOPRI
+COL is_ver_ge_19_11    NEW_V is_ver_ge_19_11    NOPRI
+COL is_ver_ge_21       NEW_V is_ver_ge_21       NOPRI
+COL is_ver_ge_23       NEW_V is_ver_ge_23       NOPRI
 
 -- Set skip version variables. Value will be '--' when version is the corresponding.
-COL skip_ver_eq_9_1    new_v skip_ver_eq_9_1    nopri
-COL skip_ver_eq_9_2    new_v skip_ver_eq_9_2    nopri
-COL skip_ver_eq_9      new_v skip_ver_eq_9      nopri
-COL skip_ver_eq_10_1   new_v skip_ver_eq_10_1   nopri
-COL skip_ver_eq_10_2   new_v skip_ver_eq_10_2   nopri
-COL skip_ver_eq_10     new_v skip_ver_eq_10     nopri
-COL skip_ver_eq_11_1   new_v skip_ver_eq_11_1   nopri
-COL skip_ver_eq_11_2   new_v skip_ver_eq_11_2   nopri
-COL skip_ver_eq_11_201 new_v skip_ver_eq_11_201 nopri
-COL skip_ver_eq_11_203 new_v skip_ver_eq_11_203 nopri
-COL skip_ver_eq_11     new_v skip_ver_eq_11     nopri
-COL skip_ver_eq_12_1   new_v skip_ver_eq_12_1   nopri
-COL skip_ver_eq_12_101 new_v skip_ver_eq_12_101 nopri
-COL skip_ver_eq_12_2   new_v skip_ver_eq_12_2   nopri
-COL skip_ver_eq_12     new_v skip_ver_eq_12     nopri
-COL skip_ver_eq_18     new_v skip_ver_eq_18     nopri
-COL skip_ver_eq_19     new_v skip_ver_eq_19     nopri
-COL skip_ver_eq_20     new_v skip_ver_eq_20     nopri
+COL skip_ver_eq_9_1    NEW_V skip_ver_eq_9_1    NOPRI
+COL skip_ver_eq_9_2    NEW_V skip_ver_eq_9_2    NOPRI
+COL skip_ver_eq_9      NEW_V skip_ver_eq_9      NOPRI
+COL skip_ver_eq_10_1   NEW_V skip_ver_eq_10_1   NOPRI
+COL skip_ver_eq_10_2   NEW_V skip_ver_eq_10_2   NOPRI
+COL skip_ver_eq_10     NEW_V skip_ver_eq_10     NOPRI
+COL skip_ver_eq_11_1   NEW_V skip_ver_eq_11_1   NOPRI
+COL skip_ver_eq_11_2   NEW_V skip_ver_eq_11_2   NOPRI
+COL skip_ver_eq_11_201 NEW_V skip_ver_eq_11_201 NOPRI
+COL skip_ver_eq_11_203 NEW_V skip_ver_eq_11_203 NOPRI
+COL skip_ver_eq_11_204 NEW_V skip_ver_eq_11_204 NOPRI
+COL skip_ver_eq_11     NEW_V skip_ver_eq_11     NOPRI
+COL skip_ver_eq_12_1   NEW_V skip_ver_eq_12_1   NOPRI
+COL skip_ver_eq_12_101 NEW_V skip_ver_eq_12_101 NOPRI
+COL skip_ver_eq_12_2   NEW_V skip_ver_eq_12_2   NOPRI
+COL skip_ver_eq_12     NEW_V skip_ver_eq_12     NOPRI
+COL skip_ver_eq_18     NEW_V skip_ver_eq_18     NOPRI
+COL skip_ver_eq_19     NEW_V skip_ver_eq_19     NOPRI
+COL skip_ver_eq_19_10  NEW_V skip_ver_eq_19_10  NOPRI
+COL skip_ver_eq_19_11  NEW_V skip_ver_eq_19_11  NOPRI
+COL skip_ver_eq_21     NEW_V skip_ver_eq_21     NOPRI
+COL skip_ver_eq_23     NEW_V skip_ver_eq_23     NOPRI
 --
-COL skip_ver_le_9_1    new_v skip_ver_le_9_1    nopri
-COL skip_ver_le_9_2    new_v skip_ver_le_9_2    nopri
-COL skip_ver_le_9      new_v skip_ver_le_9      nopri
-COL skip_ver_le_10_1   new_v skip_ver_le_10_1   nopri
-COL skip_ver_le_10_2   new_v skip_ver_le_10_2   nopri
-COL skip_ver_le_10     new_v skip_ver_le_10     nopri
-COL skip_ver_le_11_1   new_v skip_ver_le_11_1   nopri
-COL skip_ver_le_11_2   new_v skip_ver_le_11_2   nopri
-COL skip_ver_le_11_201 new_v skip_ver_le_11_201 nopri
-COL skip_ver_le_11_203 new_v skip_ver_le_11_203 nopri
-COL skip_ver_le_11     new_v skip_ver_le_11     nopri
-COL skip_ver_le_12_1   new_v skip_ver_le_12_1   nopri
-COL skip_ver_le_12_101 new_v skip_ver_le_12_101 nopri
-COL skip_ver_le_12_2   new_v skip_ver_le_12_2   nopri
-COL skip_ver_le_12     new_v skip_ver_le_12     nopri
-COL skip_ver_le_18     new_v skip_ver_le_18     nopri
-COL skip_ver_le_19     new_v skip_ver_le_19     nopri
-COL skip_ver_le_20     new_v skip_ver_le_20     nopri
+COL skip_ver_le_9_1    NEW_V skip_ver_le_9_1    NOPRI
+COL skip_ver_le_9_2    NEW_V skip_ver_le_9_2    NOPRI
+COL skip_ver_le_9      NEW_V skip_ver_le_9      NOPRI
+COL skip_ver_le_10_1   NEW_V skip_ver_le_10_1   NOPRI
+COL skip_ver_le_10_2   NEW_V skip_ver_le_10_2   NOPRI
+COL skip_ver_le_10     NEW_V skip_ver_le_10     NOPRI
+COL skip_ver_le_11_1   NEW_V skip_ver_le_11_1   NOPRI
+COL skip_ver_le_11_2   NEW_V skip_ver_le_11_2   NOPRI
+COL skip_ver_le_11_201 NEW_V skip_ver_le_11_201 NOPRI
+COL skip_ver_le_11_203 NEW_V skip_ver_le_11_203 NOPRI
+COL skip_ver_le_11_204 NEW_V skip_ver_le_11_204 NOPRI
+COL skip_ver_le_11     NEW_V skip_ver_le_11     NOPRI
+COL skip_ver_le_12_1   NEW_V skip_ver_le_12_1   NOPRI
+COL skip_ver_le_12_101 NEW_V skip_ver_le_12_101 NOPRI
+COL skip_ver_le_12_2   NEW_V skip_ver_le_12_2   NOPRI
+COL skip_ver_le_12     NEW_V skip_ver_le_12     NOPRI
+COL skip_ver_le_18     NEW_V skip_ver_le_18     NOPRI
+COL skip_ver_le_19     NEW_V skip_ver_le_19     NOPRI
+COL skip_ver_le_19_10  NEW_V skip_ver_le_19_10  NOPRI
+COL skip_ver_le_19_11  NEW_V skip_ver_le_19_11  NOPRI
+COL skip_ver_le_21     NEW_V skip_ver_le_21     NOPRI
+COL skip_ver_le_23     NEW_V skip_ver_le_23     NOPRI
 --
-COL skip_ver_ge_9_1    new_v skip_ver_ge_9_1    nopri
-COL skip_ver_ge_9_2    new_v skip_ver_ge_9_2    nopri
-COL skip_ver_ge_9      new_v skip_ver_ge_9      nopri
-COL skip_ver_ge_10_1   new_v skip_ver_ge_10_1   nopri
-COL skip_ver_ge_10_2   new_v skip_ver_ge_10_2   nopri
-COL skip_ver_ge_10     new_v skip_ver_ge_10     nopri
-COL skip_ver_ge_11_1   new_v skip_ver_ge_11_1   nopri
-COL skip_ver_ge_11_2   new_v skip_ver_ge_11_2   nopri
-COL skip_ver_ge_11     new_v skip_ver_ge_11     nopri
-COL skip_ver_ge_12_1   new_v skip_ver_ge_12_1   nopri
-COL skip_ver_ge_12_2   new_v skip_ver_ge_12_2   nopri
-COL skip_ver_ge_12     new_v skip_ver_ge_12     nopri
-COL skip_ver_ge_18     new_v skip_ver_ge_18     nopri
-COL skip_ver_ge_19     new_v skip_ver_ge_19     nopri
-COL skip_ver_ge_20     new_v skip_ver_ge_20     nopri
+COL skip_ver_ge_9_1    NEW_V skip_ver_ge_9_1    NOPRI
+COL skip_ver_ge_9_2    NEW_V skip_ver_ge_9_2    NOPRI
+COL skip_ver_ge_9      NEW_V skip_ver_ge_9      NOPRI
+COL skip_ver_ge_10_1   NEW_V skip_ver_ge_10_1   NOPRI
+COL skip_ver_ge_10_2   NEW_V skip_ver_ge_10_2   NOPRI
+COL skip_ver_ge_10     NEW_V skip_ver_ge_10     NOPRI
+COL skip_ver_ge_11_1   NEW_V skip_ver_ge_11_1   NOPRI
+COL skip_ver_ge_11_2   NEW_V skip_ver_ge_11_2   NOPRI
+COL skip_ver_ge_11_201 NEW_V skip_ver_ge_11_201 NOPRI
+COL skip_ver_ge_11_203 NEW_V skip_ver_ge_11_203 NOPRI
+COL skip_ver_ge_11_204 NEW_V skip_ver_ge_11_204 NOPRI
+COL skip_ver_ge_11     NEW_V skip_ver_ge_11     NOPRI
+COL skip_ver_ge_12_1   NEW_V skip_ver_ge_12_1   NOPRI
+COL skip_ver_ge_12_101 NEW_V skip_ver_ge_12_101 NOPRI
+COL skip_ver_ge_12_2   NEW_V skip_ver_ge_12_2   NOPRI
+COL skip_ver_ge_12     NEW_V skip_ver_ge_12     NOPRI
+COL skip_ver_ge_18     NEW_V skip_ver_ge_18     NOPRI
+COL skip_ver_ge_19     NEW_V skip_ver_ge_19     NOPRI
+COL skip_ver_ge_19_10  NEW_V skip_ver_ge_19_10  NOPRI
+COL skip_ver_ge_19_11  NEW_V skip_ver_ge_19_11  NOPRI
+COL skip_ver_ge_21     NEW_V skip_ver_ge_21     NOPRI
+COL skip_ver_ge_23     NEW_V skip_ver_ge_23     NOPRI
+
+-- If database is 18c+, then leverage the v$instance.version_full column for determining the version release
+COL version_col        NEW_V version_col        NOPRI
+select case
+          when to_number(substr(version,1,instr(version,'.')-1)) >= 18 then 'version_full'
+          else 'version'
+       end version_col
+  from v$instance;
 
 select -- Equal
-       case when version = 9 and release = 1                     then 'Y' else 'N' end is_ver_eq_9_1,
-       case when version = 9 and release = 2                     then 'Y' else 'N' end is_ver_eq_9_2,
-       case when version = 9                                     then 'Y' else 'N' end is_ver_eq_9,
-       case when version = 10 and release = 1                    then 'Y' else 'N' end is_ver_eq_10_1,
-       case when version = 10 and release = 2                    then 'Y' else 'N' end is_ver_eq_10_2,
-       case when version = 10                                    then 'Y' else 'N' end is_ver_eq_10,
-       case when version = 11 and release = 1                    then 'Y' else 'N' end is_ver_eq_11_1,
-       case when version = 11 and release = 2                    then 'Y' else 'N' end is_ver_eq_11_2,
-       case when version = 11 and release = 2 and component = 1  then 'Y' else 'N' end is_ver_eq_11_201,
-       case when version = 11 and release = 2 and component = 3  then 'Y' else 'N' end is_ver_eq_11_203,
-       case when version = 11                                    then 'Y' else 'N' end is_ver_eq_11,
-       case when version = 12 and release = 1                    then 'Y' else 'N' end is_ver_eq_12_1,
-       case when version = 12 and release = 1 and component = 1  then 'Y' else 'N' end is_ver_eq_12_101,
-       case when version = 12 and release = 2                    then 'Y' else 'N' end is_ver_eq_12_2,
-       case when version = 12                                    then 'Y' else 'N' end is_ver_eq_12,
-       case when version = 18                                    then 'Y' else 'N' end is_ver_eq_18,
-       case when version = 19                                    then 'Y' else 'N' end is_ver_eq_19,
-       case when version = 20                                    then 'Y' else 'N' end is_ver_eq_20,
+       case when version = 9 and release = 1                       then 'Y' else 'N' end is_ver_eq_9_1,
+       case when version = 9 and release = 2                       then 'Y' else 'N' end is_ver_eq_9_2,
+       case when version = 9                                       then 'Y' else 'N' end is_ver_eq_9,
+       case when version = 10 and release = 1                      then 'Y' else 'N' end is_ver_eq_10_1,
+       case when version = 10 and release = 2                      then 'Y' else 'N' end is_ver_eq_10_2,
+       case when version = 10                                      then 'Y' else 'N' end is_ver_eq_10,
+       case when version = 11 and release = 1                      then 'Y' else 'N' end is_ver_eq_11_1,
+       case when version = 11 and release = 2                      then 'Y' else 'N' end is_ver_eq_11_2,
+       case when version = 11 and release = 2 and component = 1    then 'Y' else 'N' end is_ver_eq_11_201,
+       case when version = 11 and release = 2 and component = 3    then 'Y' else 'N' end is_ver_eq_11_203,
+       case when version = 11 and release = 2 and component = 4    then 'Y' else 'N' end is_ver_eq_11_204,
+       case when version = 11                                      then 'Y' else 'N' end is_ver_eq_11,
+       case when version = 12 and release = 1                      then 'Y' else 'N' end is_ver_eq_12_1,
+       case when version = 12 and release = 1 and component = 1    then 'Y' else 'N' end is_ver_eq_12_101,
+       case when version = 12 and release = 2                      then 'Y' else 'N' end is_ver_eq_12_2,
+       case when version = 12                                      then 'Y' else 'N' end is_ver_eq_12,
+       case when version = 18                                      then 'Y' else 'N' end is_ver_eq_18,
+       case when version = 19                                      then 'Y' else 'N' end is_ver_eq_19,
+       case when version = 19 and release = 10                     then 'Y' else 'N' end is_ver_eq_19_10,
+       case when version = 19 and release = 11                     then 'Y' else 'N' end is_ver_eq_19_11,
+       case when version = 21                                      then 'Y' else 'N' end is_ver_eq_21,
+       case when version = 23                                      then 'Y' else 'N' end is_ver_eq_23,
        -- Lower or Equal
-       case when version <  9  or (version = 9 and release = 1)  then 'Y' else 'N' end is_ver_le_9_1,
-       case when version <= 9                                    then 'Y' else 'N' end is_ver_le_9_2,
-       case when version <= 9                                    then 'Y' else 'N' end is_ver_le_9,
-       case when version <  10 or (version = 10 and release = 1) then 'Y' else 'N' end is_ver_le_10_1,
-       case when version <= 10                                   then 'Y' else 'N' end is_ver_le_10_2,
-       case when version <= 10                                   then 'Y' else 'N' end is_ver_le_10,
-       case when version <  11 or (version = 11 and release = 1) then 'Y' else 'N' end is_ver_le_11_1,
-       case when version <= 11                                   then 'Y' else 'N' end is_ver_le_11_2,
-       case when version <= 11 or (version = 11 and release = 1)
+       case when version <  9  or (version = 9 and release = 1)    then 'Y' else 'N' end is_ver_le_9_1,
+       case when version <= 9                                      then 'Y' else 'N' end is_ver_le_9_2,
+       case when version <= 9                                      then 'Y' else 'N' end is_ver_le_9,
+       case when version <  10 or (version = 10 and release = 1)   then 'Y' else 'N' end is_ver_le_10_1,
+       case when version <= 10                                     then 'Y' else 'N' end is_ver_le_10_2,
+       case when version <= 10                                     then 'Y' else 'N' end is_ver_le_10,
+       case when version <  11 or (version = 11 and release = 1)   then 'Y' else 'N' end is_ver_le_11_1,
+       case when version <= 11                                     then 'Y' else 'N' end is_ver_le_11_2,
+       case when version <  11 or (version = 11 and release = 1)
                                or (version = 11 and release = 2 and component <= 1)
-                                   							     then 'Y' else 'N' end is_ver_le_11_201,
-       case when version <= 11 or (version = 11 and release = 1)
+                                                                   then 'Y' else 'N' end is_ver_le_11_201,
+       case when version <  11 or (version = 11 and release = 1)
                                or (version = 11 and release = 2 and component <= 3)
-                                   							     then 'Y' else 'N' end is_ver_le_11_203,
-       case when version <= 11                                   then 'Y' else 'N' end is_ver_le_11,
-       case when version <  12 or (version = 12 and release = 1) then 'Y' else 'N' end is_ver_le_12_1,
-       case when version <= 12 or (version = 12 and release = 1 and component <= 1)
-                                   							     then 'Y' else 'N' end is_ver_le_12_101,
-       case when version <= 12                                   then 'Y' else 'N' end is_ver_le_12_2,
-       case when version <= 12                                   then 'Y' else 'N' end is_ver_le_12,
-       case when version <= 18                                   then 'Y' else 'N' end is_ver_le_18,
-       case when version <= 19                                   then 'Y' else 'N' end is_ver_le_19,
-       case when version <= 20                                   then 'Y' else 'N' end is_ver_le_20,
+                                                                   then 'Y' else 'N' end is_ver_le_11_203,
+       case when version <  11 or (version = 11 and release = 1)
+                               or (version = 11 and release = 2 and component <= 4)
+                                                                   then 'Y' else 'N' end is_ver_le_11_204,
+       case when version <= 11                                     then 'Y' else 'N' end is_ver_le_11,
+       case when version <  12 or (version = 12 and release = 1)   then 'Y' else 'N' end is_ver_le_12_1,
+       case when version <  12 or (version = 12 and release = 1 and component <= 1)
+                                                                   then 'Y' else 'N' end is_ver_le_12_101,
+       case when version <= 12                                     then 'Y' else 'N' end is_ver_le_12_2,
+       case when version <= 12                                     then 'Y' else 'N' end is_ver_le_12,
+       case when version <= 18                                     then 'Y' else 'N' end is_ver_le_18,
+       case when version <= 19                                     then 'Y' else 'N' end is_ver_le_19,
+       case when version <  19 or (version = 19 and release <= 10) then 'Y' else 'N' end is_ver_le_19_10,
+       case when version <  19 or (version = 19 and release <= 11) then 'Y' else 'N' end is_ver_le_19_11,
+       case when version <= 21                                     then 'Y' else 'N' end is_ver_le_21,
+       case when version <= 23                                     then 'Y' else 'N' end is_ver_le_23,
        -- Greater or Equal
-       case when version >= 9                                    then 'Y' else 'N' end is_ver_ge_9_1,
-       case when version >  9  or (version = 9 and release = 2)  then 'Y' else 'N' end is_ver_ge_9_2,
-       case when version >= 9                                    then 'Y' else 'N' end is_ver_ge_9,
-       case when version >= 10                                   then 'Y' else 'N' end is_ver_ge_10_1,
-       case when version >  10 or (version = 10 and release = 2) then 'Y' else 'N' end is_ver_ge_10_2,
-       case when version >= 10                                   then 'Y' else 'N' end is_ver_ge_10,
-       case when version >= 11                                   then 'Y' else 'N' end is_ver_ge_11_1,
-       case when version >  11 or (version = 11 and release = 2) then 'Y' else 'N' end is_ver_ge_11_2,
-       case when version >= 11                                   then 'Y' else 'N' end is_ver_ge_11,
-       case when version >= 12                                   then 'Y' else 'N' end is_ver_ge_12_1,
-       case when version >  12 or (version = 12 and release = 2) then 'Y' else 'N' end is_ver_ge_12_2,
-       case when version >= 12                                   then 'Y' else 'N' end is_ver_ge_12,
-       case when version >= 18                                   then 'Y' else 'N' end is_ver_ge_18,
-       case when version >= 19                                   then 'Y' else 'N' end is_ver_ge_19,
-       case when version >= 20                                   then 'Y' else 'N' end is_ver_ge_20
-from  (select to_number(substr(version,1,instr(version,'.')-1)) version
-       ,      to_number(substr(version,instr(version,'.')+1, instr(version,'.',1,2)-instr(version,'.')-1)) release
-       ,      to_number(substr(version,instr(version,'.',1,2)+1, instr(version,'.',1,3)-instr(version,'.',1,2)-1)) server
-       ,      to_number(substr(version,instr(version,'.',1,3)+1, instr(version,'.',1,4)-instr(version,'.',1,3)-1)) component
+       case when version >= 9                                      then 'Y' else 'N' end is_ver_ge_9_1,
+       case when version >  9  or (version = 9 and release = 2)    then 'Y' else 'N' end is_ver_ge_9_2,
+       case when version >= 9                                      then 'Y' else 'N' end is_ver_ge_9,
+       case when version >= 10                                     then 'Y' else 'N' end is_ver_ge_10_1,
+       case when version >  10 or (version = 10 and release = 2)   then 'Y' else 'N' end is_ver_ge_10_2,
+       case when version >= 10                                     then 'Y' else 'N' end is_ver_ge_10,
+       case when version >= 11                                     then 'Y' else 'N' end is_ver_ge_11_1,
+       case when version >  11 or (version = 11 and release = 2)   then 'Y' else 'N' end is_ver_ge_11_2,
+       case when version >  11 or (version = 11 and release = 2 and component >= 1)
+                                                                   then 'Y' else 'N' end is_ver_ge_11_201,
+       case when version >  11 or (version = 11 and release = 2 and component >= 3)
+                                                                   then 'Y' else 'N' end is_ver_ge_11_203,
+       case when version >  11 or (version = 11 and release = 2 and component >= 4)
+                                                                   then 'Y' else 'N' end is_ver_ge_11_204,
+       case when version >= 11                                     then 'Y' else 'N' end is_ver_ge_11,
+       case when version >= 12                                     then 'Y' else 'N' end is_ver_ge_12_1,
+       case when version >  12 or (version = 12 and release = 1 and component >= 1)
+                                                                   then 'Y' else 'N' end is_ver_ge_12_101,
+       case when version >  12 or (version = 12 and release = 2)   then 'Y' else 'N' end is_ver_ge_12_2,
+       case when version >= 12                                     then 'Y' else 'N' end is_ver_ge_12,
+       case when version >= 18                                     then 'Y' else 'N' end is_ver_ge_18,
+       case when version >= 19                                     then 'Y' else 'N' end is_ver_ge_19,
+       case when version >  19 or (version = 19 and release >= 10) then 'Y' else 'N' end is_ver_ge_19_10,
+       case when version >  19 or (version = 19 and release >= 11) then 'Y' else 'N' end is_ver_ge_19_11,
+       case when version >= 21                                     then 'Y' else 'N' end is_ver_ge_21,
+       case when version >= 23                                     then 'Y' else 'N' end is_ver_ge_23
+from  (select to_number(substr(&&version_col.,1,instr(&&version_col.,'.')-1)) version
+       ,      to_number(substr(&&version_col.,instr(&&version_col.,'.')+1, instr(&&version_col.,'.',1,2)-instr(&&version_col.,'.')-1)) release
+       ,      to_number(substr(&&version_col.,instr(&&version_col.,'.',1,2)+1, instr(&&version_col.,'.',1,3)-instr(&&version_col.,'.',1,2)-1)) server
+       ,      to_number(substr(&&version_col.,instr(&&version_col.,'.',1,3)+1, instr(&&version_col.,'.',1,4)-instr(&&version_col.,'.',1,3)-1)) component
        from   v$instance);
 
 select -- Equal
@@ -184,6 +243,7 @@ select -- Equal
        decode('&&is_ver_eq_11_2.'   ,'Y','--','N','') skip_ver_eq_11_2,
        decode('&&is_ver_eq_11_201.' ,'Y','--','N','') skip_ver_eq_11_201,
        decode('&&is_ver_eq_11_203.' ,'Y','--','N','') skip_ver_eq_11_203,
+       decode('&&is_ver_eq_11_204.' ,'Y','--','N','') skip_ver_eq_11_204,
        decode('&&is_ver_eq_11.'     ,'Y','--','N','') skip_ver_eq_11,
        decode('&&is_ver_eq_12_101.' ,'Y','--','N','') skip_ver_eq_12_101,
        decode('&&is_ver_eq_12_1.'   ,'Y','--','N','') skip_ver_eq_12_1,
@@ -191,7 +251,10 @@ select -- Equal
        decode('&&is_ver_eq_12.'     ,'Y','--','N','') skip_ver_eq_12,
        decode('&&is_ver_eq_18.'     ,'Y','--','N','') skip_ver_eq_18,
        decode('&&is_ver_eq_19.'     ,'Y','--','N','') skip_ver_eq_19,
-       decode('&&is_ver_eq_20.'     ,'Y','--','N','') skip_ver_eq_20,
+       decode('&&is_ver_eq_19_10.'  ,'Y','--','N','') skip_ver_eq_19_10,
+       decode('&&is_ver_eq_19_11.'  ,'Y','--','N','') skip_ver_eq_19_11,
+       decode('&&is_ver_eq_21.'     ,'Y','--','N','') skip_ver_eq_21,
+       decode('&&is_ver_eq_23.'     ,'Y','--','N','') skip_ver_eq_23,
        -- Lower or Equal
        decode('&&is_ver_le_9_1.'    ,'Y','--','N','') skip_ver_le_9_1,
        decode('&&is_ver_le_9_2.'    ,'Y','--','N','') skip_ver_le_9_2,
@@ -201,8 +264,9 @@ select -- Equal
        decode('&&is_ver_le_10.'     ,'Y','--','N','') skip_ver_le_10,
        decode('&&is_ver_le_11_1.'   ,'Y','--','N','') skip_ver_le_11_1,
        decode('&&is_ver_le_11_2.'   ,'Y','--','N','') skip_ver_le_11_2,
-	   decode('&&is_ver_le_11_201.' ,'Y','--','N','') skip_ver_le_11_201,
-	   decode('&&is_ver_le_11_203.' ,'Y','--','N','') skip_ver_le_11_203,
+       decode('&&is_ver_le_11_201.' ,'Y','--','N','') skip_ver_le_11_201,
+       decode('&&is_ver_le_11_203.' ,'Y','--','N','') skip_ver_le_11_203,
+       decode('&&is_ver_le_11_204.' ,'Y','--','N','') skip_ver_le_11_204,
        decode('&&is_ver_le_11.'     ,'Y','--','N','') skip_ver_le_11,
        decode('&&is_ver_le_12_1.'   ,'Y','--','N','') skip_ver_le_12_1,
        decode('&&is_ver_le_12_101.' ,'Y','--','N','') skip_ver_le_12_101,
@@ -210,7 +274,10 @@ select -- Equal
        decode('&&is_ver_le_12.'     ,'Y','--','N','') skip_ver_le_12,
        decode('&&is_ver_le_18.'     ,'Y','--','N','') skip_ver_le_18,
        decode('&&is_ver_le_19.'     ,'Y','--','N','') skip_ver_le_19,
-       decode('&&is_ver_le_20.'     ,'Y','--','N','') skip_ver_le_20,
+       decode('&&is_ver_le_19_10.'  ,'Y','--','N','') skip_ver_le_19_10,
+       decode('&&is_ver_le_19_11.'  ,'Y','--','N','') skip_ver_le_19_11,
+       decode('&&is_ver_le_21.'     ,'Y','--','N','') skip_ver_le_21,
+       decode('&&is_ver_le_23.'     ,'Y','--','N','') skip_ver_le_23,
        -- Greater or Equal
        decode('&&is_ver_ge_9_1.'    ,'Y','--','N','') skip_ver_ge_9_1,
        decode('&&is_ver_ge_9_2.'    ,'Y','--','N','') skip_ver_ge_9_2,
@@ -220,144 +287,181 @@ select -- Equal
        decode('&&is_ver_ge_10.'     ,'Y','--','N','') skip_ver_ge_10,
        decode('&&is_ver_ge_11_1.'   ,'Y','--','N','') skip_ver_ge_11_1,
        decode('&&is_ver_ge_11_2.'   ,'Y','--','N','') skip_ver_ge_11_2,
+       decode('&&is_ver_ge_11_201.' ,'Y','--','N','') skip_ver_ge_11_201,
+       decode('&&is_ver_ge_11_203.' ,'Y','--','N','') skip_ver_ge_11_203,
+       decode('&&is_ver_ge_11_204.' ,'Y','--','N','') skip_ver_ge_11_204,
        decode('&&is_ver_ge_11.'     ,'Y','--','N','') skip_ver_ge_11,
        decode('&&is_ver_ge_12_1.'   ,'Y','--','N','') skip_ver_ge_12_1,
+       decode('&&is_ver_ge_12_101.' ,'Y','--','N','') skip_ver_ge_12_101,
        decode('&&is_ver_ge_12_2.'   ,'Y','--','N','') skip_ver_ge_12_2,
        decode('&&is_ver_ge_12.'     ,'Y','--','N','') skip_ver_ge_12,
        decode('&&is_ver_ge_18.'     ,'Y','--','N','') skip_ver_ge_18,
        decode('&&is_ver_ge_19.'     ,'Y','--','N','') skip_ver_ge_19,
-       decode('&&is_ver_ge_20.'     ,'Y','--','N','') skip_ver_ge_20
+       decode('&&is_ver_ge_19_10.'  ,'Y','--','N','') skip_ver_ge_19_10,
+       decode('&&is_ver_ge_19_11.'  ,'Y','--','N','') skip_ver_ge_19_11,
+       decode('&&is_ver_ge_21.'     ,'Y','--','N','') skip_ver_ge_21,
+       decode('&&is_ver_ge_23.'     ,'Y','--','N','') skip_ver_ge_23
 from   dual;
 
-COL is_ver_eq_9_1      clear
-COL is_ver_eq_9_2      clear
-COL is_ver_eq_9        clear
-COL is_ver_eq_10_1     clear
-COL is_ver_eq_10_2     clear
-COL is_ver_eq_10       clear
-COL is_ver_eq_11_1     clear
-COL is_ver_eq_11_2     clear
-COL is_ver_eq_11_201   clear
-COL is_ver_eq_11_203   clear
-COL is_ver_eq_11       clear
-COL is_ver_eq_12_1     clear
-COL is_ver_eq_12_101   clear
-COL is_ver_eq_12_2     clear
-COL is_ver_eq_12       clear
-COL is_ver_eq_18       clear
-COL is_ver_eq_19       clear
-COL is_ver_eq_20       clear
+COL is_ver_eq_9_1      CLEAR
+COL is_ver_eq_9_2      CLEAR
+COL is_ver_eq_9        CLEAR
+COL is_ver_eq_10_1     CLEAR
+COL is_ver_eq_10_2     CLEAR
+COL is_ver_eq_10       CLEAR
+COL is_ver_eq_11_1     CLEAR
+COL is_ver_eq_11_2     CLEAR
+COL is_ver_eq_11_201   CLEAR
+COL is_ver_eq_11_203   CLEAR
+COL is_ver_eq_11_204   CLEAR
+COL is_ver_eq_11       CLEAR
+COL is_ver_eq_12_1     CLEAR
+COL is_ver_eq_12_101   CLEAR
+COL is_ver_eq_12_2     CLEAR
+COL is_ver_eq_12       CLEAR
+COL is_ver_eq_18       CLEAR
+COL is_ver_eq_19       CLEAR
+COL is_ver_eq_19_10    CLEAR
+COL is_ver_eq_19_11    CLEAR
+COL is_ver_eq_21       CLEAR
+COL is_ver_eq_23       CLEAR
 --
-COL is_ver_le_9_1      clear
-COL is_ver_le_9_2      clear
-COL is_ver_le_9        clear
-COL is_ver_le_10_1     clear
-COL is_ver_le_10_2     clear
-COL is_ver_le_10       clear
-COL is_ver_le_11_1     clear
-COL is_ver_le_11_2     clear
-COL is_ver_le_11_201   clear
-COL is_ver_le_11_203   clear
-COL is_ver_le_11       clear
-COL is_ver_le_12_1     clear
-COL is_ver_le_12_101   clear
-COL is_ver_le_12_2     clear
-COL is_ver_le_12       clear
-COL is_ver_le_18       clear
-COL is_ver_le_19       clear
-COL is_ver_le_20       clear
+COL is_ver_le_9_1      CLEAR
+COL is_ver_le_9_2      CLEAR
+COL is_ver_le_9        CLEAR
+COL is_ver_le_10_1     CLEAR
+COL is_ver_le_10_2     CLEAR
+COL is_ver_le_10       CLEAR
+COL is_ver_le_11_1     CLEAR
+COL is_ver_le_11_2     CLEAR
+COL is_ver_le_11_201   CLEAR
+COL is_ver_le_11_203   CLEAR
+COL is_ver_le_11_204   CLEAR
+COL is_ver_le_11       CLEAR
+COL is_ver_le_12_1     CLEAR
+COL is_ver_le_12_101   CLEAR
+COL is_ver_le_12_2     CLEAR
+COL is_ver_le_12       CLEAR
+COL is_ver_le_18       CLEAR
+COL is_ver_le_19       CLEAR
+COL is_ver_le_19_10    CLEAR
+COL is_ver_le_19_11    CLEAR
+COL is_ver_le_21       CLEAR
+COL is_ver_le_23       CLEAR
 --
-COL is_ver_ge_9_1      clear
-COL is_ver_ge_9_2      clear
-COL is_ver_ge_9        clear
-COL is_ver_ge_10_1     clear
-COL is_ver_ge_10_2     clear
-COL is_ver_ge_10       clear
-COL is_ver_ge_11_1     clear
-COL is_ver_ge_11_2     clear
-COL is_ver_ge_11       clear
-COL is_ver_ge_12_1     clear
-COL is_ver_ge_12_2     clear
-COL is_ver_ge_12       clear
-COL is_ver_ge_18       clear
-COL is_ver_ge_19       clear
-COL is_ver_ge_20       clear
+COL is_ver_ge_9_1      CLEAR
+COL is_ver_ge_9_2      CLEAR
+COL is_ver_ge_9        CLEAR
+COL is_ver_ge_10_1     CLEAR
+COL is_ver_ge_10_2     CLEAR
+COL is_ver_ge_10       CLEAR
+COL is_ver_ge_11_1     CLEAR
+COL is_ver_ge_11_2     CLEAR
+COL is_ver_ge_11_201   CLEAR
+COL is_ver_ge_11_203   CLEAR
+COL is_ver_ge_11_204   CLEAR
+COL is_ver_ge_11       CLEAR
+COL is_ver_ge_12_1     CLEAR
+COL is_ver_ge_12_101   CLEAR
+COL is_ver_ge_12_2     CLEAR
+COL is_ver_ge_12       CLEAR
+COL is_ver_ge_18       CLEAR
+COL is_ver_ge_19       CLEAR
+COL is_ver_ge_19_10    CLEAR
+COL is_ver_ge_19_11    CLEAR
+COL is_ver_ge_21       CLEAR
+COL is_ver_ge_23       CLEAR
 
-COL skip_ver_eq_9_1    clear
-COL skip_ver_eq_9_2    clear
-COL skip_ver_eq_9      clear
-COL skip_ver_eq_10_1   clear
-COL skip_ver_eq_10_2   clear
-COL skip_ver_eq_10     clear
-COL skip_ver_eq_11_1   clear
-COL skip_ver_eq_11_2   clear
-COL skip_ver_eq_11_201 clear
-COL skip_ver_eq_11_203 clear
-COL skip_ver_eq_11     clear
-COL skip_ver_eq_12_1   clear
-COL skip_ver_eq_12_101 clear
-COL skip_ver_eq_12_2   clear
-COL skip_ver_eq_12     clear
-COL skip_ver_eq_18     clear
-COL skip_ver_eq_19     clear
-COL skip_ver_eq_20     clear
+COL skip_ver_eq_9_1    CLEAR
+COL skip_ver_eq_9_2    CLEAR
+COL skip_ver_eq_9      CLEAR
+COL skip_ver_eq_10_1   CLEAR
+COL skip_ver_eq_10_2   CLEAR
+COL skip_ver_eq_10     CLEAR
+COL skip_ver_eq_11_1   CLEAR
+COL skip_ver_eq_11_2   CLEAR
+COL skip_ver_eq_11_201 CLEAR
+COL skip_ver_eq_11_203 CLEAR
+COL skip_ver_eq_11_204 CLEAR
+COL skip_ver_eq_11     CLEAR
+COL skip_ver_eq_12_1   CLEAR
+COL skip_ver_eq_12_101 CLEAR
+COL skip_ver_eq_12_2   CLEAR
+COL skip_ver_eq_12     CLEAR
+COL skip_ver_eq_18     CLEAR
+COL skip_ver_eq_19     CLEAR
+COL skip_ver_eq_19_10  CLEAR
+COL skip_ver_eq_19_11  CLEAR
+COL skip_ver_eq_21     CLEAR
+COL skip_ver_eq_23     CLEAR
 --
-COL skip_ver_le_9_1    clear
-COL skip_ver_le_9_2    clear
-COL skip_ver_le_9      clear
-COL skip_ver_le_10_1   clear
-COL skip_ver_le_10_2   clear
-COL skip_ver_le_10     clear
-COL skip_ver_le_11_1   clear
-COL skip_ver_le_11_2   clear
-COL skip_ver_le_11_201 clear
-COL skip_ver_le_11_203 clear
-COL skip_ver_le_11     clear
-COL skip_ver_le_12_1   clear
-COL skip_ver_le_12_101 clear
-COL skip_ver_le_12_2   clear
-COL skip_ver_le_12     clear
-COL skip_ver_le_18     clear
-COL skip_ver_le_19     clear
-COL skip_ver_le_20     clear
+COL skip_ver_le_9_1    CLEAR
+COL skip_ver_le_9_2    CLEAR
+COL skip_ver_le_9      CLEAR
+COL skip_ver_le_10_1   CLEAR
+COL skip_ver_le_10_2   CLEAR
+COL skip_ver_le_10     CLEAR
+COL skip_ver_le_11_1   CLEAR
+COL skip_ver_le_11_2   CLEAR
+COL skip_ver_le_11_201 CLEAR
+COL skip_ver_le_11_203 CLEAR
+COL skip_ver_le_11_204 CLEAR
+COL skip_ver_le_11     CLEAR
+COL skip_ver_le_12_1   CLEAR
+COL skip_ver_le_12_101 CLEAR
+COL skip_ver_le_12_2   CLEAR
+COL skip_ver_le_12     CLEAR
+COL skip_ver_le_18     CLEAR
+COL skip_ver_le_19     CLEAR
+COL skip_ver_le_19_10  CLEAR
+COL skip_ver_le_19_11  CLEAR
+COL skip_ver_le_21     CLEAR
+COL skip_ver_le_23     CLEAR
 --
-COL skip_ver_ge_9_1    clear
-COL skip_ver_ge_9_2    clear
-COL skip_ver_ge_9      clear
-COL skip_ver_ge_10_1   clear
-COL skip_ver_ge_10_2   clear
-COL skip_ver_ge_10     clear
-COL skip_ver_ge_11_1   clear
-COL skip_ver_ge_11_2   clear
-COL skip_ver_ge_11     clear
-COL skip_ver_ge_12_1   clear
-COL skip_ver_ge_12_2   clear
-COL skip_ver_ge_12     clear
-COL skip_ver_ge_18     clear
-COL skip_ver_ge_19     clear
-COL skip_ver_ge_20     clear
+COL skip_ver_ge_9_1    CLEAR
+COL skip_ver_ge_9_2    CLEAR
+COL skip_ver_ge_9      CLEAR
+COL skip_ver_ge_10_1   CLEAR
+COL skip_ver_ge_10_2   CLEAR
+COL skip_ver_ge_10     CLEAR
+COL skip_ver_ge_11_1   CLEAR
+COL skip_ver_ge_11_2   CLEAR
+COL skip_ver_ge_11_201 CLEAR
+COL skip_ver_ge_11_203 CLEAR
+COL skip_ver_ge_11_204 CLEAR
+COL skip_ver_ge_11     CLEAR
+COL skip_ver_ge_12_1   CLEAR
+COL skip_ver_ge_12_101 CLEAR
+COL skip_ver_ge_12_2   CLEAR
+COL skip_ver_ge_12     CLEAR
+COL skip_ver_ge_18     CLEAR
+COL skip_ver_ge_19     CLEAR
+COL skip_ver_ge_19_10  CLEAR
+COL skip_ver_ge_19_11  CLEAR
+COL skip_ver_ge_21     CLEAR
+COL skip_ver_ge_23     CLEAR
 
 -------------------------------
 -- Set is_cdb variable. Result will be 'Y' or 'N'.
 
-COL is_cdb new_v is_cdb nopri
+COL is_cdb NEW_V is_cdb NOPRI
 select
 &&skip_ver_le_11. case when SYS_CONTEXT('USERENV','CON_ID') = 1 then 'Y' else 'N' end is_cdb
 &&skip_ver_ge_12. 'N' is_cdb
 from dual;
-COL is_cdb new_v clear
+COL is_cdb NEW_V CLEAR
 
 -------------------------------
 
-COL skip_cdb     new_v skip_cdb     nopri
-COL skip_noncdb  new_v skip_noncdb  nopri
+COL skip_cdb     NEW_V skip_cdb     NOPRI
+COL skip_noncdb  NEW_V skip_noncdb  NOPRI
 
 select
 decode('&&is_cdb.','Y','','N','--') skip_noncdb,
 decode('&&is_cdb.','Y','--','N','') skip_cdb
 from dual;
 
-COL skip_cdb    clear
-COL skip_noncdb clear
+COL skip_cdb    CLEAR
+COL skip_noncdb CLEAR
 
 -------------------------------


### PR DESCRIPTION
1) Added new variables for some minor releases (needed for other tools that leverage the MOAT370 framework).  Including:
- 11.2.0.4
- 19.10
- 19.11

2) Oracle version 20c was released to GA and eventually became 21c.  Also support for 23c is needed.  Adjusted accordingly.

3) Fix bug with inclusion of equal sign on some comparisons - specific example: `case when version <= 11 or ...` when defining variable `is_ver_le_11_201`.  This would evaluate to '**Y**' even when the database release is **11.2.0.4** when it should evaluate to '**N**'.

4) Syntax standardization, alignment, and keyword case adjustments.

**NOTE**: file `./cfg/version.cfg` not updated in this PR.