### PR TITLE
Allow for an optional custom style.css file in the ${moat370_sw_folder}/cfg directory

### DIFF
--- a/sh/moat370_0b_pre.sh
+++ b/sh/moat370_0b_pre.sh
@@ -577,7 +577,11 @@ fi
 
 fc_zip_file "${moat370_zip_filename}" "${moat370_sw_output_fdr}/LICENSE-3RD-PARTY.txt"
 
-cp "${moat370_fdr_js}/style.css" "${moat370_sw_output_fdr}/${moat370_style_css}" >> "${moat370_log3}"
+if [ -r "${moat370_sw_folder}/cfg/style.css" ] && [ -s "${moat370_sw_folder}/cfg/style.css" ]; then
+  cp "${moat370_sw_folder}/cfg/style.css" "${moat370_sw_output_fdr}/${moat370_style_css}" >>"${moat370_log3}"
+else
+  cp "${moat370_fdr_js}/style.css" "${moat370_sw_output_fdr}/${moat370_style_css}" >>"${moat370_log3}"
+fi
 
 fc_zip_file "${moat370_zip_filename}" "${moat370_sw_output_fdr}/${moat370_style_css}"
 


### PR DESCRIPTION
Simple enhancement: allow a custom `style.css` to be provided in the `${moat370_sw_folder}/cfg` directory.
- If present, use the one in the cfg directory.
- If not present, use the MOAT370 default.

**NOTE**: file `./cfg/version.cfg` not updated in this PR.